### PR TITLE
[FEAT] 상품 상세 페이지 조회 API 기능 추가

### DIFF
--- a/src/main/java/org/sopt/server/controller/ProductController.java
+++ b/src/main/java/org/sopt/server/controller/ProductController.java
@@ -5,6 +5,7 @@ import org.sopt.server.common.dto.ResponseDto;
 import org.sopt.server.service.ProductService;
 import org.sopt.server.service.dto.ProductDetailDto;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/products")
+@RequestMapping("/api/products")
 public class ProductController {
 
     private final ProductService productService;
@@ -20,7 +21,7 @@ public class ProductController {
     @GetMapping("/{productId}")
     public ResponseDto<ProductDetailDto> getProductDetailInfo(
             @RequestHeader(name = "memberId") final Long memberId,
-            @RequestParam(name = "productId") final Long productId
+            @PathVariable(name = "productId") final Long productId
     ) {
         return ResponseDto.success(productService.getProductDetailInfo(memberId, productId));
     }

--- a/src/main/java/org/sopt/server/controller/ProductController.java
+++ b/src/main/java/org/sopt/server/controller/ProductController.java
@@ -1,0 +1,27 @@
+package org.sopt.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.common.dto.ResponseDto;
+import org.sopt.server.service.ProductService;
+import org.sopt.server.service.dto.ProductDetailDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/products")
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping("/{productId}")
+    public ResponseDto<ProductDetailDto> getProductDetailInfo(
+            @RequestHeader(name = "memberId") final Long memberId,
+            @RequestParam(name = "productId") final Long productId
+    ) {
+        return ResponseDto.success(productService.getProductDetailInfo(memberId, productId));
+    }
+}

--- a/src/main/java/org/sopt/server/domain/Like.java
+++ b/src/main/java/org/sopt/server/domain/Like.java
@@ -1,6 +1,7 @@
 package org.sopt.server.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,11 +21,11 @@ public class Like {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(targetEntity = Member.class)
+    @ManyToOne(targetEntity = Member.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(targetEntity = Product.class)
+    @ManyToOne(targetEntity = Product.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 }

--- a/src/main/java/org/sopt/server/domain/Member.java
+++ b/src/main/java/org/sopt/server/domain/Member.java
@@ -2,6 +2,7 @@ package org.sopt.server.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,6 +26,6 @@ public class Member {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Like> likedProducts;
 }

--- a/src/main/java/org/sopt/server/domain/Product.java
+++ b/src/main/java/org/sopt/server/domain/Product.java
@@ -2,15 +2,21 @@ package org.sopt.server.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.server.domain.type.Category;
 
 @Entity
 @Getter
@@ -31,14 +37,25 @@ public class Product {
     @Column(name = "price", nullable = false)
     private Integer price;
 
-    @Column(name = "original_price", nullable = false)
+    /* nullable */
+    @Column(name = "original_price")
     private Integer originalPrice;
 
-    @Column(name = "card_price", nullable = false)
+    /* nullable */
+    @Column(name = "card_price")
     private Integer cardPrice;
 
     @Column(name = "is_gs_discount", nullable = false)
     private boolean isGsDiscount;
+
+    /* nullable */
+    @Column(name = "category")
+    @Enumerated(value = EnumType.STRING)
+    private Category category;
+
+    @PrimaryKeyJoinColumn(name = "product_detail_info_id")
+    @OneToOne(mappedBy = "product", fetch = FetchType.LAZY)
+    private ProductDetail productDetail;
 
     @OneToMany(mappedBy = "product")
     private List<Like> likedMembers;

--- a/src/main/java/org/sopt/server/domain/Product.java
+++ b/src/main/java/org/sopt/server/domain/Product.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
 import java.util.List;
 import lombok.AccessLevel;

--- a/src/main/java/org/sopt/server/domain/Product.java
+++ b/src/main/java/org/sopt/server/domain/Product.java
@@ -53,7 +53,6 @@ public class Product {
     @Enumerated(value = EnumType.STRING)
     private Category category;
 
-    @PrimaryKeyJoinColumn(name = "product_detail_info_id")
     @OneToOne(mappedBy = "product", fetch = FetchType.LAZY)
     private ProductDetail productDetail;
 

--- a/src/main/java/org/sopt/server/domain/Product.java
+++ b/src/main/java/org/sopt/server/domain/Product.java
@@ -55,9 +55,9 @@ public class Product {
     @OneToOne(mappedBy = "product", fetch = FetchType.LAZY)
     private ProductDetail productDetail;
 
-    @OneToMany(mappedBy = "product")
+    @OneToMany(mappedBy = "product", fetch = FetchType.LAZY)
     private List<Like> likedMembers;
 
-    @OneToMany(mappedBy = "product")
+    @OneToMany(mappedBy = "product", fetch = FetchType.LAZY)
     private List<Review> reviews;
 }

--- a/src/main/java/org/sopt/server/domain/ProductDetail.java
+++ b/src/main/java/org/sopt/server/domain/ProductDetail.java
@@ -1,0 +1,40 @@
+package org.sopt.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "product_details")
+public class ProductDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "thumbnail", nullable = false)
+    private String thumbnail;
+
+    @Column(name = "detail_image", nullable = false)
+    private String detailImage;
+
+    @Column(name = "is_receive_available", nullable = false)
+    private boolean isReceiveAvailable;
+
+    /* OneToOne에서는 관계의 소유자만 mappedBy 사용 */
+    /* mappedBy 옵션 제거 -> Product에서 ProductDetail 조인하지 못하는 문제 해결 */
+    @OneToOne(fetch = FetchType.LAZY)
+    @PrimaryKeyJoinColumn(name = "product_id")
+    private Product product;
+}

--- a/src/main/java/org/sopt/server/domain/ProductDetail.java
+++ b/src/main/java/org/sopt/server/domain/ProductDetail.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/org/sopt/server/domain/ProductDetail.java
+++ b/src/main/java/org/sopt/server/domain/ProductDetail.java
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
@@ -35,6 +36,6 @@ public class ProductDetail {
     /* OneToOne에서는 관계의 소유자만 mappedBy 사용 */
     /* mappedBy 옵션 제거 -> Product에서 ProductDetail 조인하지 못하는 문제 해결 */
     @OneToOne(fetch = FetchType.LAZY)
-    @PrimaryKeyJoinColumn(name = "product_id")
+    @JoinColumn(name = "product_id")
     private Product product;
 }

--- a/src/main/java/org/sopt/server/domain/Review.java
+++ b/src/main/java/org/sopt/server/domain/Review.java
@@ -27,8 +27,9 @@ public class Review {
     @Column(name = "content", nullable = false)
     private String content;
 
+    /* TODO: .0 또는 .5 단위의 소수만 가능하게 제한 */
     @Column(name = "star", nullable = false)
-    private Integer star;
+    private Float star;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")

--- a/src/main/java/org/sopt/server/domain/type/Category.java
+++ b/src/main/java/org/sopt/server/domain/type/Category.java
@@ -1,0 +1,16 @@
+package org.sopt.server.domain.type;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Category {
+
+    BREAD("빵"),
+    REFRIGERATED_CONVINIENCE("냉장간편식"),
+    ;
+
+    private final String category;
+}

--- a/src/main/java/org/sopt/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/server/exception/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {IllegalArgumentException.class, MethodArgumentTypeMismatchException.class})
-    public ResponseDto<?> handleIllegalArgumentException(final Exception e) {
+    public ResponseDto<?> handleIllegalArgumentException(final IllegalArgumentException e) {
         log.error(e.getMessage());
         return ResponseDto.fail(e);
     }
@@ -20,6 +20,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {CommonException.class})
     public ResponseDto<?> handleCommonException(final CommonException e) {
         log.error(e.getMessage());
+        e.printStackTrace();
         return ResponseDto.fail(HttpStatus.INTERNAL_SERVER_ERROR, e);
     }
 }

--- a/src/main/java/org/sopt/server/exception/dto/ErrorCode.java
+++ b/src/main/java/org/sopt/server/exception/dto/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
     /* 400 - BAD REQUEST */
     BAD_REQUEST(40000, HttpStatus.BAD_REQUEST, "Bad Request"),
+    STAR_DECIMAL_POINT(40001, HttpStatus.BAD_REQUEST, "별점은 .0 또는 .5 단위의 소수만 가능합니다."),
 
     /* 401 - UNAUTHORIZED */
     UNAUTHORIZED(40100, HttpStatus.UNAUTHORIZED, "Unauthorized"),

--- a/src/main/java/org/sopt/server/exception/dto/ErrorCode.java
+++ b/src/main/java/org/sopt/server/exception/dto/ErrorCode.java
@@ -9,12 +9,28 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ErrorCode {
 
+    /* 400 - BAD REQUEST */
     BAD_REQUEST(40000, HttpStatus.BAD_REQUEST, "Bad Request"),
+
+    /* 401 - UNAUTHORIZED */
     UNAUTHORIZED(40100, HttpStatus.UNAUTHORIZED, "Unauthorized"),
+
+    /* 403 - FORBIDDEN */
     FORBIDDEN(40300, HttpStatus.FORBIDDEN, "Forbidden"),
+
+    /* 404 - NOT FOUND */
     NOT_FOUND(40400, HttpStatus.NOT_FOUND, "Not Found"),
+    MEMBER_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "Member Not Found"),
+    PRODUCT_NOT_FOUND(40402, HttpStatus.NOT_FOUND, "Product Not Found"),
+    PRODUCT_DETAIL_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "Product Detail Not Found"),
+
+    /* 405 - METHOD NOT ALLOWED */
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "Method Not Allowed"),
+
+    /* 409 - CONFLICT */
     CONFLICT(40900, HttpStatus.CONFLICT, "Conflict"),
+
+    /* 500 - INTERNAL SERVER ERROR */
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     ;
 

--- a/src/main/java/org/sopt/server/exception/dto/ExceptionDto.java
+++ b/src/main/java/org/sopt/server/exception/dto/ExceptionDto.java
@@ -1,7 +1,9 @@
 package org.sopt.server.exception.dto;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public class ExceptionDto {
     private final String code;

--- a/src/main/java/org/sopt/server/repository/LikeRepository.java
+++ b/src/main/java/org/sopt/server/repository/LikeRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.server.repository;
+
+import java.util.Optional;
+import org.sopt.server.domain.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByMemberIdAndProductId(final Long memberId, final Long productId);
+}

--- a/src/main/java/org/sopt/server/repository/ProductDetailRepository.java
+++ b/src/main/java/org/sopt/server/repository/ProductDetailRepository.java
@@ -1,0 +1,17 @@
+package org.sopt.server.repository;
+
+import java.util.Optional;
+import org.sopt.server.domain.ProductDetail;
+import org.sopt.server.exception.CommonException;
+import org.sopt.server.exception.dto.ErrorCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductDetailRepository extends JpaRepository<ProductDetail, Long> {
+
+    default ProductDetail findByProductIdOrThrow(final Long productId) {
+        return findByProductId(productId).orElseThrow(() -> new CommonException(ErrorCode.PRODUCT_DETAIL_NOT_FOUND));
+    }
+    Optional<ProductDetail> findByProductId(final Long productId);
+}

--- a/src/main/java/org/sopt/server/repository/ProductRepository.java
+++ b/src/main/java/org/sopt/server/repository/ProductRepository.java
@@ -1,0 +1,17 @@
+package org.sopt.server.repository;
+
+import java.util.Optional;
+import org.sopt.server.domain.Product;
+import org.sopt.server.exception.CommonException;
+import org.sopt.server.exception.dto.ErrorCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    default Product findByIdOrThrow(final Long productId) {
+        return findById(productId).orElseThrow(() -> new CommonException(ErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    Optional<Product> findById(final Long productId);
+}

--- a/src/main/java/org/sopt/server/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/server/repository/ReviewRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.server.repository;
+
+import java.util.List;
+import org.sopt.server.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findAllByProductId(final Long productId);
+}

--- a/src/main/java/org/sopt/server/service/ProductService.java
+++ b/src/main/java/org/sopt/server/service/ProductService.java
@@ -7,6 +7,8 @@ import org.sopt.server.domain.Like;
 import org.sopt.server.domain.Product;
 import org.sopt.server.domain.ProductDetail;
 import org.sopt.server.domain.Review;
+import org.sopt.server.exception.CommonException;
+import org.sopt.server.exception.dto.ErrorCode;
 import org.sopt.server.repository.LikeRepository;
 import org.sopt.server.repository.ProductDetailRepository;
 import org.sopt.server.repository.ProductRepository;
@@ -42,18 +44,21 @@ public class ProductService {
         List<Float> stars = reviews.stream().map(Review::getStar).toList();
 
         /*
-        * 메모리와 API 명세를 고려하여 Float 자료형으로 하였으나, 스트림 API로 별점을 계산하기 위해 타입 변환이 필요하였습니다.
-        * 리뷰가 엄청 많지 않아 당장 문제는 없지만, 아래와 같은 방법으로 수정할 수 있습니다.
-        * 1. stream 대신 전통적인 for문 사용
-        * 2. 메모리 사용량이 조금 커지더라도 별점을 Double로 정의
-        * 의견 주시면 반영하도록 하겠습니다!
-        *  */
-        float starRating;
-        if (stars.isEmpty()) {
-            starRating = 0.0f;
-        } else {
-            starRating = (float) stars.stream().mapToDouble(Float::doubleValue).sum() / stars.size();
+         * 메모리와 API 명세를 고려하여 Float 자료형으로 하였으나, 스트림 API로 별점을 계산하기 위해 타입 변환이 필요하였습니다.
+         * 리뷰가 엄청 많지 않아 당장 문제는 없지만, 아래와 같은 방법으로 수정할 수 있습니다.
+         * 1. stream 대신 전통적인 for문 사용
+         * 2. 메모리 사용량이 조금 커지더라도 별점을 Double로 정의
+         * -> 논의 후 for문 사용
+         *  */
+        float starRating = 0.0f;
+        for (Float star : stars) {
+            if (star % 0.5f != 0.0f) {
+                throw new CommonException(ErrorCode.STAR_DECIMAL_POINT);
+            }
+            starRating += star;
         }
+        starRating /= stars.size();
+        starRating = Math.round(starRating * 10) / 10.0f; /* 한 자리 수까지 표현 */
 
         return ProductDetailDto.of(product, productDetail, isLiked, starRating, reviewCount);
     }

--- a/src/main/java/org/sopt/server/service/ProductService.java
+++ b/src/main/java/org/sopt/server/service/ProductService.java
@@ -1,0 +1,60 @@
+package org.sopt.server.service;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.domain.Like;
+import org.sopt.server.domain.Product;
+import org.sopt.server.domain.ProductDetail;
+import org.sopt.server.domain.Review;
+import org.sopt.server.repository.LikeRepository;
+import org.sopt.server.repository.ProductDetailRepository;
+import org.sopt.server.repository.ProductRepository;
+import org.sopt.server.repository.ReviewRepository;
+import org.sopt.server.service.dto.ProductDetailDto;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final LikeRepository likeRepository;
+    private final ProductDetailRepository productDetailRepository;
+    private final ReviewRepository reviewRepository;
+
+    public ProductDetailDto getProductDetailInfo(final Long memberId, final Long productId) {
+
+        Product product = productRepository.findByIdOrThrow(productId);
+
+        /* product detail info: thumbnail, detail image, is receive available */
+        ProductDetail productDetail = productDetailRepository.findByProductIdOrThrow(productId);
+
+        /* isLiked */
+        Optional<Like> like = likeRepository.findByMemberIdAndProductId(memberId, productId);
+        boolean isLiked = like.isPresent();
+
+        /* review count */
+        List<Review> reviews = reviewRepository.findAllByProductId(productId);
+        int reviewCount = reviews.size();
+
+        /* star rating */
+        List<Float> stars = reviews.stream().map(Review::getStar).toList();
+
+        /*
+        * 메모리와 API 명세를 고려하여 Float 자료형으로 하였으나, 스트림 API로 별점을 계산하기 위해 타입 변환이 필요하였습니다.
+        * 리뷰가 엄청 많지 않아 당장 문제는 없지만, 아래와 같은 방법으로 수정할 수 있습니다.
+        * 1. stream 대신 전통적인 for문 사용
+        * 2. 메모리 사용량이 조금 커지더라도 별점을 Double로 정의
+        * 의견 주시면 반영하도록 하겠습니다!
+        *  */
+        float starRating;
+        if (stars.isEmpty()) {
+            starRating = 0.0f;
+        } else {
+            starRating = (float) stars.stream().mapToDouble(Float::doubleValue).sum() / stars.size();
+        }
+
+        return ProductDetailDto.of(product, productDetail, isLiked, starRating, reviewCount);
+    }
+}

--- a/src/main/java/org/sopt/server/service/dto/ProductDetailDto.java
+++ b/src/main/java/org/sopt/server/service/dto/ProductDetailDto.java
@@ -1,0 +1,32 @@
+package org.sopt.server.service.dto;
+
+import lombok.Builder;
+import lombok.NonNull;
+import org.sopt.server.domain.Product;
+import org.sopt.server.domain.ProductDetail;
+
+@Builder
+public record ProductDetailDto(
+        String thumbnail,
+        String title,
+        Boolean isLiked,
+        Integer price,
+        Boolean isReceiveAvailable,
+        Float starRating,
+        Integer reviewCount,
+        String detailImage
+) {
+
+    public static ProductDetailDto of(final Product product, final ProductDetail productDetail, final Boolean isLiked, final Float starRating, final Integer reviewCount) {
+        return ProductDetailDto.builder()
+                .thumbnail(productDetail.getThumbnail())
+                .title(product.getTitle())
+                .isLiked(isLiked)
+                .price(product.getPrice())
+                .isReceiveAvailable(productDetail.isReceiveAvailable())
+                .starRating(starRating)
+                .reviewCount(reviewCount)
+                .detailImage(productDetail.getDetailImage())
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] 기능 추가
- [FIX] 에러 수정, 버그 수정
- [CHORE] gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] README, 문서
- [REFACTOR] 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
close #4 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- 상품 상세 페이지를 조회하기 위해 필요한 GET API입니다.
- 예외 처리 관련하여 의도한 예외 응답이 반환되지 않는 에러를 수정하였습니다.
- Review의 별점을 Float으로 수정하였습니다.

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
<!-- Reviewers, Assignees, Labels 지정해주세요 -->
1. 예외 처리 로직 수정한 부분
ExeptionDto에서 `@Getter`를 지정해주지 않아서 공통 응답 dto에 ExceptionDto가 들어가는 경우, ExceptionDto에서 정의한대로 반환되지 않고 발생하는 기본 에러가 그대로 반환하는 문제가 발생했습니다.
ExceptionDto의 필드를 가져오지 못하는게 원인이어서, 게터를 추가해줬습니다
https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/blob/368c987acb480814b2c98f2936baf8731098e46b/src/main/java/org/sopt/server/exception/dto/ExceptionDto.java#L6-L15

2. @PrimaryJoinColumn
`@OneToOne` 관계에서 콜럼 이름을 지정해주고 싶어서 `@PrimaryJoinColumn` 어노테이션을 사용했었어요.
ex) 
```java
    @OneToOne(fetch = FetchType.LAZY)
    @PrimaryJoinColumn(name = "product_id")
    private Product product;
```

그러나 `@PrimaryJoinColumn`은 참조하는 외래 키와 기본 키가 같은 경우에만 사용되는 어노테이션으로, 이번 사례에서는 옳지 않은 사용이었습니다.
그래서 다시 `@JoinColumn`으로 바꿔주었습니다.
https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/blob/368c987acb480814b2c98f2936baf8731098e46b/src/main/java/org/sopt/server/domain/ProductDetail.java#L37-L39

3. @OneToOne과 mappedBy
엔티티 간의 참조 관계를 정의하는 경우, `mappedBy` 옵션은 관계에 주도권을 갖는 엔티티에서만 사용되는 것이라고하더라구요.
`mappedBy`를 사용할 때마다 대충대충 감으로 했었는데, 반성하고 하나 알아갑니다... ^_;

`@ManyToMany`를 사용하지 않는 것을 권장하지만, 만약 사용하는 경우에는 양쪽 엔티티 모두 주도권을 갖기 때문에 두 엔티티에서 모두 `mappedBy`를 사용해야 한다고 하네요!

https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/blob/368c987acb480814b2c98f2936baf8731098e46b/src/main/java/org/sopt/server/domain/Product.java#L55-L56

4. 별점을 Float로 사용한 건에 대하여 . . .
리스트에서 stream API를 사용해서 Float 변수들의 합을 구하려고 했는데, stream의 `mapToDouble`이라는 메소드를 사용해야만 합을 구할 수 있도록 되어 있었습니다.
그래서 다시 `(float)`으로 타입 변환을 해주어야 했는데요..!
코드를 보면 아시겠지만, 타입 변환을 하지 않았을 때보다 시간적으로 비용이 더 드는 방법입니다.
그래서 현재 프로그램의 상황/조건과 가독성, 메모리 효율성, 시간 효율성을 고려했을 때 어떤 방법이 더 좋을지 같이 고민해보는 것도 좋을 것 같아요!
https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/blob/368c987acb480814b2c98f2936baf8731098e46b/src/main/java/org/sopt/server/service/ProductService.java#L41-L56

5. ⚠️ nullable 변수 ⚠️
Product 엔티티에서 nullable이지만 `nullable=false`로 선언되었던 것들을 다시 nullable로 바꾸어주었습니다.
이 pr이 머지되고 pull 받으신 다음 쿼리 콘솔에서 아래 쿼리를 실행해주셔야 에러가 발생하지 않습니다!
```SQL
ALTER TABLE products ALTER COLUMN card_price DROP NOT NULL;
ALTER TABLE products ALTER COLUMN original_price DROP NOT NULL;
```