### PR TITLE
[FEAT] 홈 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/server/controller/HomeController.java
+++ b/src/main/java/org/sopt/server/controller/HomeController.java
@@ -1,0 +1,21 @@
+package org.sopt.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.common.dto.ResponseDto;
+import org.sopt.server.dto.response.HomeResponseDto;
+import org.sopt.server.service.HomeService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @GetMapping ("/api/")
+    public ResponseDto<HomeResponseDto> getHome() {
+        return ResponseDto.success(homeService.getHome());
+    }
+}
+

--- a/src/main/java/org/sopt/server/domain/Banner.java
+++ b/src/main/java/org/sopt/server/domain/Banner.java
@@ -1,0 +1,22 @@
+package org.sopt.server.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "banners")
+public class Banner {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "banner_imageUrl", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "banner_type", nullable = false)
+    private String type;
+}

--- a/src/main/java/org/sopt/server/dto/response/HomeResponseDto.java
+++ b/src/main/java/org/sopt/server/dto/response/HomeResponseDto.java
@@ -1,0 +1,11 @@
+package org.sopt.server.dto.response;
+
+import java.util.List;
+
+public record HomeResponseDto(
+    List<String> topBanners,
+    MonthlyEventsResponseDto  monthlyEvents,
+    List<String> bottomBanners
+) {
+
+}

--- a/src/main/java/org/sopt/server/dto/response/MonthlyEventsResponseDto.java
+++ b/src/main/java/org/sopt/server/dto/response/MonthlyEventsResponseDto.java
@@ -1,0 +1,11 @@
+package org.sopt.server.dto.response;
+
+import java.util.List;
+
+public record MonthlyEventsResponseDto(
+
+    List<String> mainBanners,
+    List<String> subBanners
+) {
+
+}

--- a/src/main/java/org/sopt/server/repository/BannerRepository.java
+++ b/src/main/java/org/sopt/server/repository/BannerRepository.java
@@ -1,0 +1,15 @@
+package org.sopt.server.repository;
+
+import org.sopt.server.domain.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+    @Query(value = "SELECT image_url FROM \"gs \".banner WHERE type = :type", nativeQuery = true)
+    List<String> findImageUrlsByType(@Param("type") String type);
+}

--- a/src/main/java/org/sopt/server/service/HomeService.java
+++ b/src/main/java/org/sopt/server/service/HomeService.java
@@ -3,20 +3,24 @@ package org.sopt.server.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.server.dto.response.HomeResponseDto;
 import org.sopt.server.dto.response.MonthlyEventsResponseDto;
+import org.sopt.server.repository.BannerRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class HomeService {
 
+    @Autowired
+    private BannerRepository bannerRepository;
+
     public HomeResponseDto getHome() {
-        List<String> topBanners = Arrays.asList("top-image-url1", "top-image-url2", "top-image-url3");
-        List<String> mainBanners = Arrays.asList("main-image-url1", "main-image-url2", "main-image-url3");
-        List<String> subBanners = Arrays.asList("sub-image-url1", "sub-image-url2", "sub-image-url3");
-        List<String> bottomBanners = Arrays.asList("bottom-image-url1", "bottom-image-url2", "bottom-image-url3");
+        List<String> topBanners = bannerRepository.findImageUrlsByType("top");
+        List<String> mainBanners = bannerRepository.findImageUrlsByType("main");
+        List<String> subBanners = bannerRepository.findImageUrlsByType("sub");
+        List<String> bottomBanners = bannerRepository.findImageUrlsByType("bottom");
 
         return new HomeResponseDto(topBanners, new MonthlyEventsResponseDto(mainBanners, subBanners), bottomBanners);
     }

--- a/src/main/java/org/sopt/server/service/HomeService.java
+++ b/src/main/java/org/sopt/server/service/HomeService.java
@@ -1,0 +1,23 @@
+package org.sopt.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.dto.response.HomeResponseDto;
+import org.sopt.server.dto.response.MonthlyEventsResponseDto;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    public HomeResponseDto getHome() {
+        List<String> topBanners = Arrays.asList("top-image-url1", "top-image-url2", "top-image-url3");
+        List<String> mainBanners = Arrays.asList("main-image-url1", "main-image-url2", "main-image-url3");
+        List<String> subBanners = Arrays.asList("sub-image-url1", "sub-image-url2", "sub-image-url3");
+        List<String> bottomBanners = Arrays.asList("bottom-image-url1", "bottom-image-url2", "bottom-image-url3");
+
+        return new HomeResponseDto(topBanners, new MonthlyEventsResponseDto(mainBanners, subBanners), bottomBanners);
+    }
+}


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] 기능 추가
- [FIX] 에러 수정, 버그 수정
- [CHORE] gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] README, 문서
- [REFACTOR] 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #3 
## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
-  top banner (이미지 3개) , monthly banner(메인 이미지 3개, 서브 이미지 3개), bottom banner (이미지 3개) 의 이미지 링크를 조회할 수 있도록 하였습니다. 
![image](https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/assets/137388764/5371860f-1221-40f6-81f5-54db65305744)

- Banner 도메인과 Banner Repository를 추가 한 후 테스트
![image](https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/assets/137388764/15dc07b1-749a-41dd-b2f0-8ac9d72d1b31)

![image](https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/assets/137388764/8f6129a9-8e1e-4425-8aa9-a493c83b43d8)



## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
<!-- Reviewers, Assignees, Labels 지정해주세요 -->
- 배너 이미지는 기획팀이 구글 드라이브에 추가한 뒤, 이미지 링크를 수정할 계획입니다 !

- banner 엔티티를 따로 만들어서 데이터 베이스에서 이미지를 가져오는게 나을지 아니면 
그냥 service단에서 이미지 링크들을 반환하는 것이 좋을지 의견 남겨주세요 ..!!! 

- 테스트는 로컬 DB에서 진행하였습니다.