### PR TITLE
[FEAT] 편의점 이벤트 product 사전 예약 화면 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/server/controller/ProductController.java
+++ b/src/main/java/org/sopt/server/controller/ProductController.java
@@ -31,7 +31,7 @@ public class ProductController {
         if (type.equals("basic")) {
             return ResponseDto.success(productService.getAdvanceReservationScreen());
         } else if (type.equals("event")) {
-            return ResponseDto.success(null);
+            return ResponseDto.success(productService.getEvenetProducts());
         } else { /* type.equals("category") */
             return ResponseDto.success(productService.getCategoryProducts());
         }

--- a/src/main/java/org/sopt/server/dto/request/LikeAddDto.java
+++ b/src/main/java/org/sopt/server/dto/request/LikeAddDto.java
@@ -1,6 +1,5 @@
 package org.sopt.server.dto.request;
 
-import lombok.Getter;
 
 public record LikeAddDto(
         Long productId

--- a/src/main/java/org/sopt/server/dto/response/EventProductsResponseDto.java
+++ b/src/main/java/org/sopt/server/dto/response/EventProductsResponseDto.java
@@ -1,6 +1,5 @@
 package org.sopt.server.dto.response;
 
-import java.util.Date;
 import java.util.List;
 
 public record EventProductsResponseDto(

--- a/src/main/java/org/sopt/server/dto/response/EventProductsResponseDto.java
+++ b/src/main/java/org/sopt/server/dto/response/EventProductsResponseDto.java
@@ -1,0 +1,14 @@
+package org.sopt.server.dto.response;
+
+import java.util.Date;
+import java.util.List;
+
+public record EventProductsResponseDto(
+    String headerTitle,
+    String date,
+    List<ProductDto> products
+) {
+    public static EventProductsResponseDto of(String headerTitle, String date, List<ProductDto> products) {
+        return new EventProductsResponseDto(headerTitle, date, products);
+    }
+}

--- a/src/main/java/org/sopt/server/service/ProductService.java
+++ b/src/main/java/org/sopt/server/service/ProductService.java
@@ -3,7 +3,6 @@ package org.sopt.server.service;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/org/sopt/server/service/ProductService.java
+++ b/src/main/java/org/sopt/server/service/ProductService.java
@@ -1,6 +1,9 @@
 package org.sopt.server.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -11,13 +14,10 @@ import org.sopt.server.domain.Like;
 import org.sopt.server.domain.Product;
 import org.sopt.server.domain.Review;
 import org.sopt.server.domain.type.Category;
-import org.sopt.server.dto.response.AdvanceReservationScreenDto;
+import org.sopt.server.dto.response.*;
 import org.sopt.server.exception.CommonException;
 import org.sopt.server.exception.dto.ErrorCode;
 import org.sopt.server.repository.*;
-import org.sopt.server.dto.response.CategoryProductsDto;
-import org.sopt.server.dto.response.ProductDetailDto;
-import org.sopt.server.dto.response.ProductDto;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -67,6 +67,21 @@ public class ProductService {
                                                 .collect(Collectors.toList());
 
         return AdvanceReservationScreenDto.of(advanceTopBanners, basicProducts);
+    }
+
+    public EventProductsResponseDto getEvenetProducts() {
+        String headerTitle = "푸냥이 푸딩젤리 2탄!복숭아맛🍑";
+
+        // 날짜 포맷 지정
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        // 현재 날짜와 현재 날짜로부터 이틀 뒤 날짜
+        String date = LocalDate.now().format(formatter) + " ~ " + LocalDate.now().plusDays(2).format(formatter);
+
+        List<ProductDto> eventProducts = productRepository.findAllByCategory(Category.EVENT).stream()
+                                                 .map(product -> ProductDto.of(product, getStarRating(product.getReviews()), product.getReviews().size()))
+                                                 .collect(Collectors.toList());
+
+        return EventProductsResponseDto.of(headerTitle, date, eventProducts);
     }
 
     private Float getStarRating(final List<Review> reviews) {


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] 기능 추가
- [FIX] 에러 수정, 버그 수정
- [CHORE] gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] README, 문서
- [REFACTOR] 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #13 
## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- 편의점 사전 예약 화면에서  event produts를 조회할 수 있도록 하였습니다. 
![image](https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/assets/137388764/f808dc94-0a50-4f12-8389-d64c6fec75f2)

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
<!-- Reviewers, Assignees, Labels 지정해주세요 -->
https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/blob/7b9d45c109d8a874729e9be824b38447a696a0c7/src/main/java/org/sopt/server/service/ProductService.java#L74-L77
-  이벤트 카테고리에 보이는 날짜는 현재 날짜와 현재 날짜 +2을 기간으로 설정했습니다. (yyyy.MM.dd 형식)

https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/blob/7b9d45c109d8a874729e9be824b38447a696a0c7/src/main/java/org/sopt/server/service/ProductService.java#L72
- 이벤트 상품이 하나로 고정되어있어서 hearTitle은 문구를 고정하였습니다. 