### PR TITLE
[FEAT] 좋아요 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/server/controller/LikeController.java
+++ b/src/main/java/org/sopt/server/controller/LikeController.java
@@ -3,14 +3,10 @@ package org.sopt.server.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.server.common.dto.ResponseDto;
-import org.sopt.server.dto.request.LikeAddDto;
-import org.sopt.server.dto.response.LikeDto;
+import org.sopt.server.dto.request.LikeRequestDto;
+import org.sopt.server.dto.response.LikeResponseDto;
 import org.sopt.server.service.LikeService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/likes")
@@ -20,10 +16,18 @@ public class LikeController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseDto<LikeDto> postLike(
+    public ResponseDto<LikeResponseDto> postLike(
             @RequestHeader("memberId") final Long memberId,
-            @RequestBody final LikeAddDto likeAddDto
+            @RequestBody final LikeRequestDto likeRequestDto
     ) {
-        return ResponseDto.success(likeService.postLike(memberId, likeAddDto));
+        return ResponseDto.success(likeService.postLike(memberId, likeRequestDto));
+    }
+
+    @DeleteMapping
+    public ResponseDto<LikeResponseDto> deleteLike(
+        @RequestHeader("memberId") final Long memberId,
+        @RequestBody final LikeRequestDto likeRequestDto
+    ) {
+        return ResponseDto.success(likeService.deleteLike(memberId, likeRequestDto));
     }
 }

--- a/src/main/java/org/sopt/server/dto/request/LikeRequestDto.java
+++ b/src/main/java/org/sopt/server/dto/request/LikeRequestDto.java
@@ -1,8 +1,6 @@
 package org.sopt.server.dto.request;
 
-import lombok.Getter;
-
-public record LikeAddDto(
+public record LikeRequestDto(
         Long productId
 ) {
 }

--- a/src/main/java/org/sopt/server/dto/response/LikeDto.java
+++ b/src/main/java/org/sopt/server/dto/response/LikeDto.java
@@ -1,9 +1,0 @@
-package org.sopt.server.dto.response;
-
-public record LikeDto(
-        boolean isLiked
-) {
-    public static LikeDto from(final boolean isLiked) {
-        return new LikeDto(isLiked);
-    }
-}

--- a/src/main/java/org/sopt/server/dto/response/LikeResponseDto.java
+++ b/src/main/java/org/sopt/server/dto/response/LikeResponseDto.java
@@ -1,0 +1,9 @@
+package org.sopt.server.dto.response;
+
+public record LikeResponseDto(
+        boolean isLiked
+) {
+    public static LikeResponseDto from(final boolean isLiked) {
+        return new LikeResponseDto(isLiked);
+    }
+}

--- a/src/main/java/org/sopt/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/server/exception/GlobalExceptionHandler.java
@@ -2,7 +2,9 @@ package org.sopt.server.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.server.common.dto.ResponseDto;
+import org.sopt.server.exception.dto.ErrorCode;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -12,15 +14,16 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {IllegalArgumentException.class, MethodArgumentTypeMismatchException.class})
-    public ResponseDto<?> handleIllegalArgumentException(final IllegalArgumentException e) {
+    public ResponseEntity<ResponseDto<?>> handleIllegalArgumentException(final IllegalArgumentException e) {
         log.error(e.getMessage());
-        return ResponseDto.fail(e);
+        return new ResponseEntity<>(ResponseDto.fail(e), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(value = {CommonException.class})
-    public ResponseDto<?> handleCommonException(final CommonException e) {
+    public ResponseEntity<ResponseDto<?>> handleCommonException(final CommonException e) {
         log.error(e.getMessage());
         e.printStackTrace();
-        return ResponseDto.fail(HttpStatus.INTERNAL_SERVER_ERROR, e);
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+        return new ResponseEntity<>(ResponseDto.fail(status, e), status);
     }
 }

--- a/src/main/java/org/sopt/server/exception/dto/ErrorCode.java
+++ b/src/main/java/org/sopt/server/exception/dto/ErrorCode.java
@@ -30,11 +30,11 @@ public enum ErrorCode {
 
     /* 409 - CONFLICT */
     CONFLICT(40900, HttpStatus.CONFLICT, "Conflict"),
+    LIKE_ALREADY_EXISTS(40901, HttpStatus.CONFLICT, "이미 좋아요를 누른 상품입니다."),
+    LIKE_ALREADY_DELETE(40902, HttpStatus.CONFLICT, "이미 좋아요를 취소한 상품입니다."),
 
     /* 500 - INTERNAL SERVER ERROR */
-    INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
-    LIKE_ALREADY_EXISTS(50001, HttpStatus.INTERNAL_SERVER_ERROR, "이미 좋아요를 누른 상품입니다."),
-    LIKE_ALREADY_DELETE(50002, HttpStatus.INTERNAL_SERVER_ERROR, "이미 좋아요를 취소한 상품입니다.")
+    INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error")
     ;
 
     final int status;

--- a/src/main/java/org/sopt/server/exception/dto/ErrorCode.java
+++ b/src/main/java/org/sopt/server/exception/dto/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     /* 500 - INTERNAL SERVER ERROR */
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     LIKE_ALREADY_EXISTS(50001, HttpStatus.INTERNAL_SERVER_ERROR, "이미 좋아요를 누른 상품입니다."),
+    LIKE_ALREADY_DELETE(50002, HttpStatus.INTERNAL_SERVER_ERROR, "이미 좋아요를 취소한 상품입니다.")
     ;
 
     final int status;

--- a/src/main/java/org/sopt/server/service/LikeService.java
+++ b/src/main/java/org/sopt/server/service/LikeService.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.server.domain.Like;
 import org.sopt.server.domain.Member;
 import org.sopt.server.domain.Product;
-import org.sopt.server.dto.request.LikeAddDto;
-import org.sopt.server.dto.response.LikeDto;
+import org.sopt.server.dto.request.LikeRequestDto;
+import org.sopt.server.dto.response.LikeResponseDto;
 import org.sopt.server.exception.CommonException;
 import org.sopt.server.exception.dto.ErrorCode;
 import org.sopt.server.repository.LikeRepository;
@@ -22,8 +22,8 @@ public class LikeService {
     private final ProductRepository productRepository;
     private final LikeRepository likeRepository;
 
-    public LikeDto postLike(final Long memberId, final LikeAddDto LikeAddDto) {
-        Long productId = LikeAddDto.productId();
+    public LikeResponseDto postLike(final Long memberId, final LikeRequestDto LikeRequestDto) {
+        Long productId = LikeRequestDto.productId();
         Optional<Like> opLike = likeRepository.findByMemberIdAndProductId(memberId, productId);
         if (opLike.isPresent()) {
             throw new CommonException(ErrorCode.LIKE_ALREADY_EXISTS);
@@ -34,6 +34,21 @@ public class LikeService {
 
         likeRepository.save(Like.of(member, product));
 
-        return LikeDto.from(true);
+        return LikeResponseDto.from(true);
+    }
+
+    public LikeResponseDto deleteLike(final Long memberId, final LikeRequestDto LikeRequestDto) {
+        // 취소할 상품이 존재하는지 먼저 확인
+        Product product = productRepository.findByIdOrThrow(LikeRequestDto.productId());
+
+        Optional<Like> opLike = likeRepository.findByMemberIdAndProductId(memberId, LikeRequestDto.productId());
+        if (opLike.isEmpty()) {
+            throw new CommonException(ErrorCode.LIKE_ALREADY_DELETE);
+        }
+
+        likeRepository.delete(opLike.get());
+
+        return LikeResponseDto.from(false);
     }
 }
+


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] 기능 추가
- [FIX] 에러 수정, 버그 수정
- [CHORE] gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] README, 문서
- [REFACTOR] 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #13 
## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- 상품에 등록된 좋아요를 삭제할 수 있도록 하였습니다
![image](https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/assets/137388764/2d28bae8-bed4-4fef-aee7-96b94d39744a)
- 이미 좋아요를 취소한 상품인 경우
![image](https://github.com/NOW-SOPT-APP7-GS-HOMETOWN/GsHometown-Server/assets/137388764/1ec29864-b7d1-43f0-b32c-1b0ef3acf16c)


## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
<!-- Reviewers, Assignees, Labels 지정해주세요 -->

- 좋아요 추가, 좋아요 삭제 API에서 모두 같은 RequestDto, ReponseDto를 쓰기 때문에 이름을 LikeRequestDto, LikeResponseDto로 통일하였습니다. 

- 좋아요 추가, 좋아요 삭제 API 명세서 fail 에 PRODUCT_NOT_FOUND(상품의 아이디를 찾을 수 없는 경우)를 추가하였습니다 !!

- 에러 발생 시 status 코드가 제대로 나오는 것 같지 않아( ex. PRODUCT_NOT_FOUND인데 상태 코드는 500) GlobalExceptionHandler를 수정하였습니당 